### PR TITLE
Moved bash scripts to common repo

### DIFF
--- a/.github/workflows/common-auto-version-and-push-to-ECR.yml
+++ b/.github/workflows/common-auto-version-and-push-to-ECR.yml
@@ -50,27 +50,26 @@ jobs:
 #          ls -al
 #          cat git_latest.sh
       
-      - name: Get common scripts
+      - name: Get common repo
         uses: actions/checkout@v3
         with:
           repository: defra-cdp-sandpit/cdp-workflows
-          path: scripts
+          path: temp_scripts
           ref: feature/common-scripts
 
       - name: File listing
         run: |
-          ls -al
-          ls -al scripts
+          ls -al temp_scripts/scripts
 
       - name: Automatic Tagging of Releases part 1
         id: latest-git-tag
         run: |
-          bash scripts/git_latest.sh
+          bash temp_scripts/scripts/git_latest.sh
 
       - name: Automatic Tagging of Releases part 2
         id: increment-git-tag
         run: |
-          bash scripts/git_update.sh -v ${{ steps.latest-git-tag.outputs.CURRENT-GIT-TAG }} -f ${{ steps.latest-git-tag.outputs.GIT-TAG-FOUND}}
+          bash temp_scripts/scripts/git_update.sh -v ${{ steps.latest-git-tag.outputs.CURRENT-GIT-TAG }} -f ${{ steps.latest-git-tag.outputs.GIT-TAG-FOUND}}
 
       - name: Set up env values
         run: |

--- a/.github/workflows/common-auto-version-and-push-to-ECR.yml
+++ b/.github/workflows/common-auto-version-and-push-to-ECR.yml
@@ -43,15 +43,20 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
+      - name: Download required scripts
+        run: |
+          curl -o versioning/git_latest.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/main/scripts/git_latest.sh
+          curl -o versioning/git_update.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/main/scripts/git_update.sh
+      
       - name: Automatic Tagging of Releases part 1
         id: latest-git-tag
         run: |
-          bash ${{ github.action_path }}/scripts/git_latest.sh
+          bash versioning/git_latest.sh
 
       - name: Automatic Tagging of Releases part 2
         id: increment-git-tag
         run: |
-          bash ${{ github.action_path }}/scripts/git_update.sh -v ${{ steps.latest-git-tag.outputs.CURRENT-GIT-TAG }} -f ${{ steps.latest-git-tag.outputs.GIT-TAG-FOUND}}
+          bash versioning/git_update.sh -v ${{ steps.latest-git-tag.outputs.CURRENT-GIT-TAG }} -f ${{ steps.latest-git-tag.outputs.GIT-TAG-FOUND}}
 
       - name: Set up env values
         run: |

--- a/.github/workflows/common-auto-version-and-push-to-ECR.yml
+++ b/.github/workflows/common-auto-version-and-push-to-ECR.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Automatic Tagging of Releases part 1
         id: latest-git-tag
         run: |
-          bash defra-cdp-sandpit/cdp-workflows/scripts/git_latest.sh
+          bash ${{ github.action_path }}/scripts/git_latest.sh
 
       - name: Automatic Tagging of Releases part 2
         id: increment-git-tag
         run: |
-          bash defra-cdp-sandpit/cdp-workflows/scripts/git_update.sh -v ${{ steps.latest-git-tag.outputs.CURRENT-GIT-TAG }} -f ${{ steps.latest-git-tag.outputs.GIT-TAG-FOUND}}
+          bash ${{ github.action_path }}/scripts/git_update.sh -v ${{ steps.latest-git-tag.outputs.CURRENT-GIT-TAG }} -f ${{ steps.latest-git-tag.outputs.GIT-TAG-FOUND}}
 
       - name: Set up env values
         run: |

--- a/.github/workflows/common-auto-version-and-push-to-ECR.yml
+++ b/.github/workflows/common-auto-version-and-push-to-ECR.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Automatic Tagging of Releases part 1
         id: latest-git-tag
         run: |
-          bash versioning/git_latest.sh
+          bash defra-cdp-sandpit/cdp-workflows/scripts/git_latest.sh
 
       - name: Automatic Tagging of Releases part 2
         id: increment-git-tag
         run: |
-          bash versioning/git_update.sh -v ${{ steps.latest-git-tag.outputs.CURRENT-GIT-TAG }} -f ${{ steps.latest-git-tag.outputs.GIT-TAG-FOUND}}
+          bash defra-cdp-sandpit/cdp-workflows/scripts/git_update.sh -v ${{ steps.latest-git-tag.outputs.CURRENT-GIT-TAG }} -f ${{ steps.latest-git-tag.outputs.GIT-TAG-FOUND}}
 
       - name: Set up env values
         run: |

--- a/.github/workflows/common-auto-version-and-push-to-ECR.yml
+++ b/.github/workflows/common-auto-version-and-push-to-ECR.yml
@@ -45,9 +45,8 @@ jobs:
 
       - name: Download required scripts
         run: |
-          pwd
-          curl -o git_latest.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/main/scripts/git_latest.sh
-          curl -o git_update.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/main/scripts/git_update.sh
+          curl -o git_latest.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_latest.sh
+          curl -o git_update.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_update.sh
           ls -al
       
       - name: Automatic Tagging of Releases part 1

--- a/.github/workflows/common-auto-version-and-push-to-ECR.yml
+++ b/.github/workflows/common-auto-version-and-push-to-ECR.yml
@@ -50,6 +50,17 @@ jobs:
           ls -al
           cat git_latest.sh
       
+      - name: Check out my other private repo
+        uses: actions/checkout@v3
+        with:
+          repository: defra-cdp-sandpit/cdp-workflows
+          path: scripts
+          ref: feature/common-scripts
+
+      - name: File listing
+        run: |
+          ls -al
+
       - name: Automatic Tagging of Releases part 1
         id: latest-git-tag
         run: |

--- a/.github/workflows/common-auto-version-and-push-to-ECR.yml
+++ b/.github/workflows/common-auto-version-and-push-to-ECR.yml
@@ -45,18 +45,20 @@ jobs:
 
       - name: Download required scripts
         run: |
-          curl -o versioning/git_latest.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/main/scripts/git_latest.sh
-          curl -o versioning/git_update.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/main/scripts/git_update.sh
+          pwd
+          curl -o git_latest.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/main/scripts/git_latest.sh
+          curl -o git_update.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/main/scripts/git_update.sh
+          ls -al
       
       - name: Automatic Tagging of Releases part 1
         id: latest-git-tag
         run: |
-          bash versioning/git_latest.sh
+          bash git_latest.sh
 
       - name: Automatic Tagging of Releases part 2
         id: increment-git-tag
         run: |
-          bash versioning/git_update.sh -v ${{ steps.latest-git-tag.outputs.CURRENT-GIT-TAG }} -f ${{ steps.latest-git-tag.outputs.GIT-TAG-FOUND}}
+          bash git_update.sh -v ${{ steps.latest-git-tag.outputs.CURRENT-GIT-TAG }} -f ${{ steps.latest-git-tag.outputs.GIT-TAG-FOUND}}
 
       - name: Set up env values
         run: |

--- a/.github/workflows/common-auto-version-and-push-to-ECR.yml
+++ b/.github/workflows/common-auto-version-and-push-to-ECR.yml
@@ -43,23 +43,11 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-#      - name: Download required scripts
-#        run: |
-#          curl -o git_latest.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_latest.sh?token=${{ secrets.GITHUB_TOKEN }}
-#          curl -o git_update.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_update.sh?token=${{ secrets.GITHUB_TOKEN }}
-#          ls -al
-#          cat git_latest.sh
-      
       - name: Get common repo
         uses: actions/checkout@v3
         with:
           repository: defra-cdp-sandpit/cdp-workflows
           path: temp_scripts
-          ref: feature/common-scripts
-
-      - name: File listing
-        run: |
-          ls -al temp_scripts/scripts
 
       - name: Automatic Tagging of Releases part 1
         id: latest-git-tag

--- a/.github/workflows/common-auto-version-and-push-to-ECR.yml
+++ b/.github/workflows/common-auto-version-and-push-to-ECR.yml
@@ -48,6 +48,7 @@ jobs:
           curl -o git_latest.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_latest.sh
           curl -o git_update.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_update.sh
           ls -al
+          cat git_latest.sh
       
       - name: Automatic Tagging of Releases part 1
         id: latest-git-tag

--- a/.github/workflows/common-auto-version-and-push-to-ECR.yml
+++ b/.github/workflows/common-auto-version-and-push-to-ECR.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Download required scripts
         run: |
-          curl -o git_latest.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_latest.sh
-          curl -o git_update.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_update.sh
+          curl -o git_latest.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_latest.sh?token=${{ secrets.GITHUB_TOKEN }}
+          curl -o git_update.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_update.sh?token=${{ secrets.GITHUB_TOKEN }}
           ls -al
           cat git_latest.sh
       

--- a/.github/workflows/common-auto-version-and-push-to-ECR.yml
+++ b/.github/workflows/common-auto-version-and-push-to-ECR.yml
@@ -43,14 +43,14 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Download required scripts
-        run: |
-          curl -o git_latest.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_latest.sh?token=${{ secrets.GITHUB_TOKEN }}
-          curl -o git_update.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_update.sh?token=${{ secrets.GITHUB_TOKEN }}
-          ls -al
-          cat git_latest.sh
+#      - name: Download required scripts
+#        run: |
+#          curl -o git_latest.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_latest.sh?token=${{ secrets.GITHUB_TOKEN }}
+#          curl -o git_update.sh https://raw.githubusercontent.com/defra-cdp-sandpit/cdp-workflows/feature/common-scripts/scripts/git_update.sh?token=${{ secrets.GITHUB_TOKEN }}
+#          ls -al
+#          cat git_latest.sh
       
-      - name: Check out my other private repo
+      - name: Get common scripts
         uses: actions/checkout@v3
         with:
           repository: defra-cdp-sandpit/cdp-workflows
@@ -60,16 +60,17 @@ jobs:
       - name: File listing
         run: |
           ls -al
+          ls -al scripts
 
       - name: Automatic Tagging of Releases part 1
         id: latest-git-tag
         run: |
-          bash git_latest.sh
+          bash scripts/git_latest.sh
 
       - name: Automatic Tagging of Releases part 2
         id: increment-git-tag
         run: |
-          bash git_update.sh -v ${{ steps.latest-git-tag.outputs.CURRENT-GIT-TAG }} -f ${{ steps.latest-git-tag.outputs.GIT-TAG-FOUND}}
+          bash scripts/git_update.sh -v ${{ steps.latest-git-tag.outputs.CURRENT-GIT-TAG }} -f ${{ steps.latest-git-tag.outputs.GIT-TAG-FOUND}}
 
       - name: Set up env values
         run: |

--- a/.github/workflows/dotnet-backend-build-and-unit-test-and-integration-test.yml
+++ b/.github/workflows/dotnet-backend-build-and-unit-test-and-integration-test.yml
@@ -27,9 +27,15 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Get common repo
+        uses: actions/checkout@v3
+        with:
+          repository: defra-cdp-sandpit/cdp-workflows
+          path: temp_scripts
+
       - name: Create nuget.config contents from secret
         run: |
-          bash versioning/create_nuget_config.sh ${{ secrets.nuget-config-including-pat }}
+          bash temp_scripts/scripts/create_nuget_config.sh ${{ secrets.nuget-config-including-pat }}
 
       - id: buildImage
         name: Build image
@@ -74,4 +80,4 @@ jobs:
       - name: Cleanup - remove nuget.config as it contains sensitive info
         if: always()
         run: |
-          bash versioning/remove_nuget_config.sh
+          bash temp_scripts/scripts/remove_nuget_config.sh

--- a/.github/workflows/dotnet-backend-build-and-unit-test.yml
+++ b/.github/workflows/dotnet-backend-build-and-unit-test.yml
@@ -27,9 +27,15 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Get common repo
+        uses: actions/checkout@v3
+        with:
+          repository: defra-cdp-sandpit/cdp-workflows
+          path: temp_scripts
+
       - name: Create nuget.config contents from secret
         run: |
-          bash versioning/create_nuget_config.sh ${{ secrets.nuget-config-including-pat }}
+          bash temp_scripts/scripts/create_nuget_config.sh ${{ secrets.nuget-config-including-pat }}
 
       - id: buildImage
         name: Build image
@@ -41,4 +47,4 @@ jobs:
       - name: Cleanup - remove nuget.config as it contains sensitive info
         if: always()
         run: |
-          bash versioning/remove_nuget_config.sh
+          bash temp_scripts/scripts/remove_nuget_config.sh

--- a/.github/workflows/dotnet-backend-pull-from-ECR-and-integration-test.yml
+++ b/.github/workflows/dotnet-backend-pull-from-ECR-and-integration-test.yml
@@ -37,9 +37,15 @@ jobs:
         with:
           dotnet-version: '6.0.x'
 
+      - name: Get common repo
+        uses: actions/checkout@v3
+        with:
+          repository: defra-cdp-sandpit/cdp-workflows
+          path: temp_scripts
+
       - name: Create nuget.config contents from secret
         run: |
-          bash versioning/create_nuget_config.sh ${{ secrets.nuget-config-including-pat }}
+          bash temp_scripts/scripts/create_nuget_config.sh ${{ secrets.nuget-config-including-pat }}
 
       - name: Install dependencies
         run: dotnet restore ${{ inputs.integration-project-and-path }}
@@ -62,7 +68,7 @@ jobs:
       - name: Find Most Recent Tag
         id: latest-git-tag
         run: |
-          bash versioning/git_latest.sh
+          bash temp_scripts/scripts/git_latest.sh
 
       - name: Create local certificates for https
         run: |
@@ -90,4 +96,4 @@ jobs:
       - name: Cleanup - remove nuget.config as it contains sensitive info
         if: always()
         run: |
-          bash versioning/remove_nuget_config.sh
+          bash temp_scripts/scripts/remove_nuget_config.sh

--- a/.github/workflows/node-frontend-pull-from-ECR-and-ui-test.yml
+++ b/.github/workflows/node-frontend-pull-from-ECR-and-ui-test.yml
@@ -42,10 +42,16 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
+      - name: Get common repo
+        uses: actions/checkout@v3
+        with:
+          repository: defra-cdp-sandpit/cdp-workflows
+          path: temp_scripts
+
       - name: Find Most Recent Tag
         id: latest-git-tag
         run: |
-          bash versioning/git_latest.sh
+          bash temp_scripts/scripts/git_latest.sh
 
       - name: Pull pre-built image and start container
         env:

--- a/scripts/create_nuget_config.sh
+++ b/scripts/create_nuget_config.sh
@@ -1,0 +1,6 @@
+# Create a nuget.config file from the GitHub secret. It will contains a PAT token to authenticate against the NuGet feed.
+# $1 is the base64-encoded contents passed in from a GitHub secret
+
+echo "$1" | base64 -d > nuget.config
+
+exit 0

--- a/scripts/git_latest.sh
+++ b/scripts/git_latest.sh
@@ -1,0 +1,46 @@
+# Read major version from file, and look for latest git tag with that major version
+
+# read major version
+MAJOR_VERSION=`cat versioning/version_config | grep -v '#' | grep -v 'release'`
+if [[ $MAJOR_VERSION == '' ]]
+then
+  MAJOR_VERSION=0
+fi
+
+# read override version (if supplied)
+OVERRIDE_VERSION=`cat versioning/version_config | grep -v '#' | grep 'release'`
+
+if [[ $OVERRIDE_VERSION == '' ]]
+then
+  # check major version is a valid integer
+  if [ -n "$MAJOR_VERSION" ] && [ "$MAJOR_VERSION" -eq "$MAJOR_VERSION" ] 2>/dev/null; then
+    echo "Major is valid number"
+  else
+    exit 1
+  fi
+
+  echo "Major version: $MAJOR_VERSION"
+
+  # get highest tag number, and add MAJOR.1.0 if doesn't exist
+  CURRENT_VERSION=`git ls-remote --tags --sort='v:refname' | grep auto-version-$MAJOR_VERSION | tail -n 1 | cut -d/ -f3 | cut -d'-' -f3`
+
+  if [[ $CURRENT_VERSION == '' ]]
+  then
+    CURRENT_VERSION="$MAJOR_VERSION.1.0"
+    echo "GIT-TAG-FOUND=false" >> $GITHUB_OUTPUT
+  else
+    echo "GIT-TAG-FOUND=true" >> $GITHUB_OUTPUT
+  fi
+fi
+
+if [[ $OVERRIDE_VERSION != '' ]]
+then
+  $CURRENT_VERSION = `echo "$OVERRIDE_VERSION" | cut -d'=' -f2`
+  echo "GIT-TAG-FOUND=false" >> $GITHUB_OUTPUT # Prevent increment
+fi
+
+echo "Current Version: $CURRENT_VERSION"
+
+echo "CURRENT-GIT-TAG=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+exit 0

--- a/scripts/git_update.sh
+++ b/scripts/git_update.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Increment minor version number, if needed
+
+CURRENT_VERSION=""
+CURRENT_VERSION_FOUND=""
+
+# get parameter
+while getopts "v:f:" flag
+do
+  case "${flag}" in
+    v) CURRENT_VERSION=${OPTARG};;
+    f) CURRENT_VERSION_FOUND=${OPTARG};;
+  esac
+done
+
+echo "Current highest version $CURRENT_VERSION"
+
+echo "Actual tag found: $CURRENT_VERSION_FOUND"
+
+# replace . with space so can split into an array
+CURRENT_VERSION_PARTS=(${CURRENT_VERSION//./ })
+
+# get number parts
+VNUM1=${CURRENT_VERSION_PARTS[0]}
+VNUM2=${CURRENT_VERSION_PARTS[1]}
+VNUM3=${CURRENT_VERSION_PARTS[2]}
+
+# only increment if a previous version tag found
+if [[ $CURRENT_VERSION_FOUND == 'true' ]]
+then
+  VNUM2=$((VNUM2+1))
+  VNUM3=0
+fi
+
+# create new tag
+NEW_TAG="$VNUM1.$VNUM2.$VNUM3"
+echo "($VERSION) updating $CURRENT_VERSION to $NEW_TAG"
+
+echo "Tagged with $NEW_TAG"
+git tag auto-version-$NEW_TAG
+git push --tags
+git push
+
+echo "GIT-TAG=$NEW_TAG" >> $GITHUB_OUTPUT
+
+exit 0

--- a/scripts/remove_nuget_config.sh
+++ b/scripts/remove_nuget_config.sh
@@ -1,0 +1,5 @@
+# Remove the nuget.config file as it contains sensitive credentials
+
+rm -f nuget.config
+
+exit 0


### PR DESCRIPTION
Rather than having the bash scripts duplicated inside each CDP service repo, store them in this common repo and reference them.
Note - this repo must be public otherwise a PAT token would be needed to checkout/download the scripts into the calling workflow to run them. As our repos will all eventually be public, it seemed unnecessary to keep int private/internal and generate PATs temporarily